### PR TITLE
Adds author

### DIFF
--- a/Llama2OnLyra.ipynb
+++ b/Llama2OnLyra.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook is inspired by this [blog post](https://huggingface.co/blog/llama2)."
+    "This notebook is inspired by this [blog post](https://huggingface.co/blog/llama2).  \n",
+    "\n",
+    "The author of this notebook is [Christoph Schnell](mailto:christoph@schnell.de) "
    ]
   },
   {


### PR DESCRIPTION
Adding yourself as the author of a Python Jupyter Notebook is a good practice for several reasons. Firstly, attribution serves as a form of professional courtesy and intellectual honesty. By clearly indicating that you are the author, you take ownership of your work, fostering transparency and accountability in the collaborative coding environment. This attribution becomes particularly relevant when sharing notebooks with colleagues, collaborators, or the wider community, as it establishes a clear line of communication about the origin of the code and insights contained within the notebook.

Secondly, authorship provides a means of contact and identification. Including your name or username in the metadata of the notebook allows others to easily identify the primary contributor, making it simpler to reach out for questions, collaboration, or further discussion. This aspect is crucial in fostering a sense of community and collaboration within the coding community.

Furthermore, when sharing code in educational or tutorial settings, adding your name as the author enhances the educational experience. Students or learners can easily attribute the content to its source, facilitating a deeper understanding of the coding practices demonstrated in the notebook.

In summary, including yourself as the author of a Python Jupyter Notebook is not just a formality but a valuable contribution to the collaborative and communicative nature of coding. It establishes accountability, facilitates collaboration, and enhances the overall educational experience for those who engage with your code.